### PR TITLE
benchmarks: compare HashTable to CPython's dict

### DIFF
--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -1,4 +1,5 @@
 tox
 pytest
+pytest-benchmark
 build
 twine

--- a/tests/hashtable_benchmark_test.py
+++ b/tests/hashtable_benchmark_test.py
@@ -1,0 +1,70 @@
+"""
+Benchmark borghash.HashTable against CPython's dict.
+"""
+
+import pytest
+
+from borghash import HashTable
+from .hashtable_test import H2
+
+
+@pytest.fixture(scope="module")
+def keys():
+    # use quite a lot of keys to reduce issues with timer resolution
+    # and outside influences onto the measurement.
+    return frozenset(H2(x) for x in range(1000000))
+
+
+def bh():  # borghash
+    return HashTable(key_size=32, value_size=4)  # 256bit keys, 4Byte (32bit) values
+
+
+def pd():  # python dict
+    return dict()
+
+
+HT_CLASSES = [bh, pd]
+
+
+def setup(ht_class, keys, fill=False):
+    ht = ht_class()
+    if fill:
+        for key in keys:
+            ht[key] = key[:4]
+    return (ht, keys), {}
+
+
+@pytest.mark.parametrize("ht_class", HT_CLASSES)
+def test_insert(benchmark, ht_class, keys):
+    def func(ht, keys):
+        for key in keys:
+            ht[key] = key[:4]
+
+    benchmark.pedantic(func, setup=lambda: setup(ht_class, keys, fill=False))
+
+
+@pytest.mark.parametrize("ht_class", HT_CLASSES)
+def test_update(benchmark, ht_class, keys):
+    def func(ht, keys):
+        for key in keys:
+            ht[key] = key[-4:]  # update value for an existing ht entry
+
+    benchmark.pedantic(func, setup=lambda: setup(ht_class, keys, fill=True))
+
+
+@pytest.mark.parametrize("ht_class", HT_CLASSES)
+def test_lookup(benchmark, ht_class, keys):
+    def func(ht, keys):
+        for key in keys:
+            assert ht[key] == key[:4]
+
+    benchmark.pedantic(func, setup=lambda: setup(ht_class, keys, fill=True))
+
+
+@pytest.mark.parametrize("ht_class", HT_CLASSES)
+def test_delete(benchmark, ht_class, keys):
+    def func(ht, keys):
+        for key in keys:
+            del ht[key]
+
+    benchmark.pedantic(func, setup=lambda: setup(ht_class, keys, fill=True))

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,7 @@
 envlist = py{39,310,311,312,313}
 
 [testenv]
-deps = pytest
-commands = pytest -v -rs
+deps =
+    pytest
+    pytest-benchmark
+commands = pytest -v -rs --benchmark-columns=mean --benchmark-sort=name --benchmark-group-by=func


### PR DESCRIPTION
bh == `borghash.HashTable` (implemented in Cython)
pd == Python's `dict` (which is implemented in C and has decades of tweaking).

`HashTable` is slower than `dict` and that's fine.

Primary goals for `HashTable` are memory efficiency, simplicity and easy to maintain code - not maximum speed.

```

--- benchmark 'test_delete': 2 tests ---
Name (time in ms)         Mean          
----------------------------------------
test_delete[bh]       220.6713 (1.18)   
test_delete[pd]       186.8163 (1.0)    
----------------------------------------

--- benchmark 'test_insert': 2 tests ---
Name (time in ms)         Mean          
----------------------------------------
test_insert[bh]       346.2284 (1.22)   
test_insert[pd]       284.2618 (1.0)    
----------------------------------------

--- benchmark 'test_lookup': 2 tests ---
Name (time in ms)         Mean          
----------------------------------------
test_lookup[bh]       379.9695 (1.33)   
test_lookup[pd]       285.4229 (1.0)    
----------------------------------------

--- benchmark 'test_update': 2 tests ---
Name (time in ms)         Mean          
----------------------------------------
test_update[bh]       299.5358 (1.14)   
test_update[pd]       261.6083 (1.0)    
----------------------------------------
```