### PR TITLE
write/read: metadata as json, struct.packed data from inner kv array

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Persistence
 ~~~~~~~~~~~
 
 ``HashTableNT`` has ``.write()`` and ``.read()`` methods to save/load its
-content to/from a file, using ``msggpack`` as an efficient binary format.
+content to/from a file, using an efficient binary format.
 
 When a ``HashTableNT`` is saved to disk, only the non-deleted entries are
 persisted and when it is loaded from disk, a new hashtable and new, dense

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 license = {text="BSD"}
-dependencies = [
-  "msgpack >=1.0.3, <=1.1.0",
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/borgbackup/borghash"

--- a/tests/hashtablent_test.py
+++ b/tests/hashtablent_test.py
@@ -159,4 +159,4 @@ def test_size(ntht, n):
         ntht.write(f)
         real_size = f.tell()
     # is our estimation good enough?
-    assert estimated_size * 0.8 < real_size < estimated_size * 1.0
+    assert estimated_size * 0.9 < real_size < estimated_size * 1.0


### PR DESCRIPTION
fixes #8.