### PR TITLE
HashTable: fix issues on 32bit platforms

### DIFF
--- a/src/borghash/HashTable.pxd
+++ b/src/borghash/HashTable.pxd
@@ -2,18 +2,18 @@ from libc.stdint cimport uint8_t, uint32_t
 
 cdef class HashTable:
     cdef int ksize, vsize
-    cdef readonly int capacity, used
-    cdef int initial_capacity, tombstones
+    cdef readonly size_t capacity, used
+    cdef size_t initial_capacity, tombstones
     cdef float max_load_factor, min_load_factor, shrink_factor, grow_factor
     cdef uint32_t* table
-    cdef int kv_capacity, kv_used
+    cdef uint32_t kv_capacity, kv_used
     cdef float kv_grow_factor
     cdef uint8_t* keys
     cdef uint8_t* values
     cdef int stats_get, stats_set, stats_del, stats_iter, stats_lookup, stats_linear
     cdef int stats_resize_table, stats_resize_kv
 
-    cdef int _get_index(self, uint8_t* key)
-    cdef int _lookup_index(self, uint8_t* key_ptr, int* index_ptr)
-    cdef void _resize_table(self, int new_capacity)
-    cdef void _resize_kv(self, int new_capacity)
+    cdef size_t _get_index(self, uint8_t* key)
+    cdef int _lookup_index(self, uint8_t* key_ptr, size_t* index_ptr)
+    cdef void _resize_table(self, size_t new_capacity)
+    cdef void _resize_kv(self, size_t new_capacity)


### PR DESCRIPTION
- RESERVED is uint32_t, so we can't assign it to a 32bit int
- in general, instead of using C int, let's rather use size_t for array indexes and sizes. size_t is unsigned, so no problem with that. it's 32bit on 32bit platforms, 64bit on 64bit platforms.
- exception: indexes into the kv array are always only uint32_t to save memory.

Note that due to the load factor of the hashtable, it makes sense to have hashtables with a bit more than 2^32 buckets even if the kv array is limited to less than 2^32.
If there would be close to 2^32 stored kv items, the hashtable would be approximately 2^33 buckets large (if the load factor is 0.5).