### PR TITLE
HashTableNT: give separate formats in value_format namedtuple

### DIFF
--- a/src/borghash/HashTableNT.pxd
+++ b/src/borghash/HashTableNT.pxd
@@ -1,6 +1,7 @@
 cdef class HashTableNT:
     cdef int key_size
     cdef object value_type
+    cdef object value_format
     cdef object value_struct
     cdef int value_size
     cdef object inner

--- a/src/borghash/__main__.py
+++ b/src/borghash/__main__.py
@@ -15,8 +15,10 @@ from .HashTableNT import HashTableNT
 
 count = 50000
 value_type = namedtuple("Chunk", ["refcount", "size"])
+value_format_t = namedtuple("ChunkFormat", ["refcount", "size"])
+value_format = value_format_t(refcount="<I", size="I")
 # 256bit (32Byte) key, 2x 32bit (4Byte) values
-ht = HashTableNT(key_size=32, value_format="<II", value_type=value_type)
+ht = HashTableNT(key_size=32, value_type=value_type, value_format=value_format)
 
 t0 = time()
 for i in range(count):

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -10,9 +10,10 @@ from borghash import HashTable, HashTableNT
 from .hashtable_test import H2
 
 VALUE_TYPE = namedtuple("value_type", "value")
-VALUE_FMT = "<I"
+VALUE_FMT_TYPE = namedtuple("value_format", "value")
+VALUE_FMT = VALUE_FMT_TYPE("<I")
 KEY_SIZE = len(H2(0))
-VALUE_SIZE = len(struct.pack(VALUE_FMT, 0))
+VALUE_SIZE = len(struct.pack("".join(VALUE_FMT), 0))
 VALUE_BITS = VALUE_SIZE * 8
 
 @pytest.fixture(scope="module")

--- a/tests/hashtablent_test.py
+++ b/tests/hashtablent_test.py
@@ -8,8 +8,9 @@ from borghash import HashTableNT
 from .hashtable_test import H2
 
 key_size = 32  # 32 bytes = 256bits key
-value_format = "<III"  # 3x little endian 32bit unsigned int
 value_type = namedtuple("vt", "v1 v2 v3")
+value_format_t = namedtuple("vf", "v1 v2 v3")
+value_format = value_format_t(v1="<I", v2="I", v3="I")  # 3x little endian 32bit unsigned int
 
 key1, value1 = b"a" * 32, value_type(11, 12, 13)
 key2, value2 = b"b" * 32, value_type(21, 22, 23)
@@ -19,7 +20,7 @@ key4, value4 = b"d" * 32, value_type(41, 42, 43)
 
 @pytest.fixture
 def ntht():
-    return HashTableNT(key_size=key_size, value_format=value_format, value_type=value_type)
+    return HashTableNT(key_size=key_size, value_type=value_type, value_format=value_format)
 
 
 @pytest.fixture
@@ -30,10 +31,10 @@ def ntht12(ntht):
 
 
 def test_init():
-    ht = HashTableNT(key_size=32, value_format=value_format, value_type=value_type)
+    ht = HashTableNT(key_size=32, value_type=value_type, value_format=value_format)
     assert len(ht) == 0
     items = [(key1, value1), (key2, value2)]
-    ht = HashTableNT(items, key_size=32, value_format=value_format, value_type=value_type)
+    ht = HashTableNT(items, key_size=32, value_type=value_type, value_format=value_format)
     assert ht[key1] == value1
     assert ht[key2] == value2
 


### PR DESCRIPTION
also: improve type checks, remove pointless defaults.

Fixes #30.