### PR TITLE
HashTableNT: deal with byte_order separately

### DIFF
--- a/src/borghash/HashTableNT.pxd
+++ b/src/borghash/HashTableNT.pxd
@@ -1,5 +1,6 @@
 cdef class HashTableNT:
     cdef int key_size
+    cdef object byte_order
     cdef object value_type
     cdef object value_format
     cdef object value_struct

--- a/src/borghash/__main__.py
+++ b/src/borghash/__main__.py
@@ -16,7 +16,7 @@ from .HashTableNT import HashTableNT
 count = 50000
 value_type = namedtuple("Chunk", ["refcount", "size"])
 value_format_t = namedtuple("ChunkFormat", ["refcount", "size"])
-value_format = value_format_t(refcount="<I", size="I")
+value_format = value_format_t(refcount="I", size="I")
 # 256bit (32Byte) key, 2x 32bit (4Byte) values
 ht = HashTableNT(key_size=32, value_type=value_type, value_format=value_format)
 

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -11,7 +11,7 @@ from .hashtable_test import H2
 
 VALUE_TYPE = namedtuple("value_type", "value")
 VALUE_FMT_TYPE = namedtuple("value_format", "value")
-VALUE_FMT = VALUE_FMT_TYPE("<I")
+VALUE_FMT = VALUE_FMT_TYPE("I")
 KEY_SIZE = len(H2(0))
 VALUE_SIZE = len(struct.pack("".join(VALUE_FMT), 0))
 VALUE_BITS = VALUE_SIZE * 8

--- a/tests/hashtablent_test.py
+++ b/tests/hashtablent_test.py
@@ -10,7 +10,7 @@ from .hashtable_test import H2
 key_size = 32  # 32 bytes = 256bits key
 value_type = namedtuple("vt", "v1 v2 v3")
 value_format_t = namedtuple("vf", "v1 v2 v3")
-value_format = value_format_t(v1="<I", v2="I", v3="I")  # 3x little endian 32bit unsigned int
+value_format = value_format_t(v1="I", v2="I", v3="I")  # 3x little endian 32bit unsigned int
 
 key1, value1 = b"a" * 32, value_type(11, 12, 13)
 key2, value2 = b"b" * 32, value_type(21, 22, 23)


### PR DESCRIPTION
the first value_format namedtuple element value should not be special by including the byte order there, especially since that byte order will apply to ALL elements.

So have it separately and prepend it to the joined elements formats.